### PR TITLE
Add missing carriage return

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -84,9 +84,8 @@ If you want to use ELK: [update your vm.max_map_count before](https://elk-docker
 
 ## Reload a server
 
-`docker exec -it apache apache2ctl -k graceful`
-
-`docker exec -it nginx nginx -s reload`
+- `docker exec -it apache apache2ctl -k graceful`
+- `docker exec -it nginx nginx -s reload`
 
 ## Connect to the Mongo database
 
@@ -98,9 +97,8 @@ If you want to use ELK: [update your vm.max_map_count before](https://elk-docker
 
 ## Build translations
 
-`docker exec -it apache ./scripts/build_lang.pl`
-
-`docker exec -it apache apache2ctl -k graceful`
+- `docker exec -it apache ./scripts/build_lang.pl`
+- `docker exec -it apache apache2ctl -k graceful`
 
 ## Run a test
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -85,6 +85,7 @@ If you want to use ELK: [update your vm.max_map_count before](https://elk-docker
 ## Reload a server
 
 `docker exec -it apache apache2ctl -k graceful`
+
 `docker exec -it nginx nginx -s reload`
 
 ## Connect to the Mongo database
@@ -98,6 +99,7 @@ If you want to use ELK: [update your vm.max_map_count before](https://elk-docker
 ## Build translations
 
 `docker exec -it apache ./scripts/build_lang.pl`
+
 `docker exec -it apache apache2ctl -k graceful`
 
 ## Run a test


### PR DESCRIPTION
Need to add two carriage returns otherwise the commands appear on the same line.
